### PR TITLE
Export markdown.css

### DIFF
--- a/packages/react-ui/scripts/build.mts
+++ b/packages/react-ui/scripts/build.mts
@@ -10,6 +10,6 @@ await Build.start()
       "src/styles/themes/default.css",
       "src/styles/themes/shadcn-extras.css",
     ],
-    cssEntrypoints: ["src/styles/index.css", "src/styles/modal.css"],
+    cssEntrypoints: ["src/styles/index.css", "src/styles/markdown.css", "src/styles/modal.css"],
   })
   .transpileTypescript();

--- a/packages/react-ui/src/styles/markdown.css
+++ b/packages/react-ui/src/styles/markdown.css
@@ -1,0 +1,1 @@
+@import "./tailwindcss/markdown.css";


### PR DESCRIPTION
https://www.assistant-ui.com/docs/legacy/styled/Markdown mentions

> import "@assistant-ui/react-ui/styles/markdown.css";

But `markdown.css` isn't actually exported. This PR exports `markdown.css`.